### PR TITLE
Add navigation to public view from landing page

### DIFF
--- a/assets/scripts/dashboard/events.js
+++ b/assets/scripts/dashboard/events.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const getFormFields = require('../../../lib/get-form-fields')
-const pageApi = require('../AJAX/pagesajax') // UPDATE THIS (change file name)
+const pageApi = require('../AJAX/pagesajax.js') // UPDATE THIS (change file name)
 const postApi = require('../AJAX/postajax.js') // UPDATE THIS
 const ui = require('./ui')
 

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -22,6 +22,6 @@ $(() => {
   views.landingPageView()
   dashEvents.addHandlers()
   authEvents.addHandlers()
-  // landingEvents.addHandlers()
+  landingEvents.addHandlers()
   // visitorEvents.addHandlers()
 })

--- a/assets/scripts/landingpage/events.js
+++ b/assets/scripts/landingpage/events.js
@@ -1,6 +1,7 @@
 'use strict'
 const siteAjax = require('../AJAX/siteajax')
 const siteListTemplate = require('../templates/sitelist.handlebars')
+const visitorEvents = require('../visitorsite/events')
 
 const getSitesSuccess = function (data) {
   const showSiteList = siteListTemplate({ sites: data.sites })
@@ -16,6 +17,23 @@ const listAllSites = function () {
     })
 }
 
+const showSignIn = function () {
+  $('#sign-in-div').show()
+  $('#sign-up-div').hide()
+}
+const showSignUp = function () {
+  $('#sign-up-div').show()
+  $('#sign-in-div').hide()
+}
+const addHandlers = function () {
+  $(document).on('click', '.site-link', (event) => {
+    const siteId = event.target.dataset.id
+    visitorEvents.loadSite(siteId)
+  })
+  $('#sign-in-link').on('click', showSignIn)
+  $('#sign-up-link').on('click', showSignUp)
+}
 module.exports = {
-  listAllSites
+  listAllSites,
+  addHandlers
 }

--- a/assets/scripts/templates/publicblog.handlebars
+++ b/assets/scripts/templates/publicblog.handlebars
@@ -1,0 +1,12 @@
+{{#if posts}}
+{{#each posts as |post|}}
+  <div class="list-group-item blog-post">
+    <h2 class="list-group-item-heading">{{post.title}}</h3>
+    <p class="list-group-item-text">{{post.content}}</p>
+    <!-- <a data-id={{post.id}} class="read-more-less">read more</a> -->
+  </div>
+  <br>
+{{/each}}
+{{else}}
+<h4>This site doesn't have any blog posts yet.</h4>
+{{/if}}

--- a/assets/scripts/visitorsite/events.js
+++ b/assets/scripts/visitorsite/events.js
@@ -1,7 +1,7 @@
 'use strict'
 const views = require('../JQviews')
 const siteAjax = require('../AJAX/siteajax')
-const postAjax = require('../AJAX/postajax')
+// const postAjax = require('../AJAX/postajax')
 const publicPostsTemplate = require('../templates/publicblog.handlebars')
 
 const loadSite = function (siteId) {

--- a/assets/scripts/visitorsite/events.js
+++ b/assets/scripts/visitorsite/events.js
@@ -1,0 +1,30 @@
+'use strict'
+const views = require('../JQviews')
+const siteAjax = require('../AJAX/siteajax')
+const postAjax = require('../AJAX/postajax')
+const publicPostsTemplate = require('../templates/publicblog.handlebars')
+
+const loadSite = function (siteId) {
+  siteAjax.getOneSite(siteId)
+    .then((siteData) => {
+      console.log('siteData is', siteData)
+      $('.navbar-brand').text(siteData.site.name)
+      return siteData.site
+    })
+    .then((data) => {
+      const showPostList = publicPostsTemplate({ posts: data.blog })
+      $('#public-posts').html(showPostList)
+      views.publicView()
+    })
+    // .then(postAjax.index)
+    // .then((posts) => {
+    //   // run post handlebars
+    //   // run site handlebars
+    //   views.publicView()
+    // })
+    .catch(() => console.log('site data not returned'))
+}
+
+module.exports = {
+  loadSite
+}


### PR DESCRIPTION
Add navigation to public view
- click handlers for site list added
- public view displays
- added handlebar for blog post list: uses the site data to display all
posts on that site.
- landing page handlers added back in on index.js

Next: 'read more' is still commented out. right now entire blog post is
displayed.